### PR TITLE
Add ember observer score to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ ember-color-palette
 ==============================================================================
 
 <img src="https://travis-ci.org/hakilebara/ember-color-palette.svg?branch=master" alt="build status"/>
+<img src="https://emberobserver.com/badges/ember-color-palette.svg" alt="ember observer score"/>
 
 Displays a color palette. Heavily inspired by https://github.com/chrislopresto/ember-freestyle.
 


### PR DESCRIPTION
The purpose of this MR is to show the ember observer score in the readme like so:
<img width="284" alt="Capture d'écran 2019-03-25 14 34 14" src="https://user-images.githubusercontent.com/16031781/54923703-1231d100-4f0b-11e9-9036-5102f6b58730.png">
